### PR TITLE
feat: [BACK-314] Ajout du webhook pour les paiements en échec

### DIFF
--- a/src/Controller/Webhook/PaymentCaptureCompletedAction.php
+++ b/src/Controller/Webhook/PaymentCaptureCompletedAction.php
@@ -80,7 +80,7 @@ final class PaymentCaptureCompletedAction
 
                 // Retrieve order details
                 $details = $this->orderDetailsApi->get($token, $data['id']);
-                if ($details['status'] === 'COMPLETED') {
+                if ($this->getDetailsStatus($details) === 'COMPLETED') {
                     $stateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
 
                     if ($stateMachine->can(PaymentTransitions::TRANSITION_COMPLETE)) {
@@ -130,5 +130,12 @@ final class PaymentCaptureCompletedAction
         }
 
         throw new PayPalWrongDataException();
+    }
+
+    private function getDetailsStatus($orderDetails)
+    {
+        if (!isset($orderDetails['status']))
+            return false;
+        return $orderDetails['status'];
     }
 }

--- a/src/Provider/PaymentProvider.php
+++ b/src/Provider/PaymentProvider.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Sylius\PayPalPlugin\Provider;
 
 use Sylius\Component\Core\Model\PaymentInterface;
-use Sylius\Component\Core\Repository\PaymentRepositoryInterface;
 use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
+use Sylius\PayPalPlugin\Repository\PaymentRepositoryInterface;
 
 final class PaymentProvider implements PaymentProviderInterface
 {
@@ -28,15 +28,11 @@ final class PaymentProvider implements PaymentProviderInterface
 
     public function getByPayPalOrderId(string $orderId): PaymentInterface
     {
-        /** @var PaymentInterface[] $payments */
-        $payments = $this->paymentRepository->findAll();
+        /** @var PaymentInterface|null $payment */
+        $payment = $this->paymentRepository->getByPayPalOrderId($orderId);
 
-        foreach ($payments as $payment) {
-            $details = $payment->getDetails();
-
-            if (isset($details['paypal_order_id']) && $details['paypal_order_id'] === $orderId) {
-                return $payment;
-            }
+        if(!is_null($payment)) {
+            return $payment;
         }
 
         throw PaymentNotFoundException::withPayPalOrderId($orderId);

--- a/src/Repository/PaymentRepository.php
+++ b/src/Repository/PaymentRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Sylius\PayPalPlugin\Repository;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\NativeQuery;
+use Sylius\Bundle\CoreBundle\Doctrine\ORM\PaymentRepository as BasePaymentRepository;
+use Sylius\Component\Core\Model\Payment;
+
+class PaymentRepository implements PaymentRepositoryInterface
+{
+    private EntityManager $entityManager;
+    private BasePaymentRepository $basePaymentRepository;
+
+    public function __construct(EntityManager $entityManager, BasePaymentRepository $basePaymentRepository)
+    {
+        $this->entityManager = $entityManager;
+        $this->basePaymentRepository = $basePaymentRepository;
+    }
+
+    public function __call($method, $arguments)
+    {
+        if (method_exists($this, $method)) {
+            return call_user_func_array($this->$method, $arguments);
+        }
+
+        return call_user_func_array($this->basePaymentRepository->$method, $arguments);
+    }
+
+    public function getByPayPalOrderId($paypalOrderId)
+    {
+        $builder = $this->basePaymentRepository->createResultSetMappingBuilder('p');
+        $builder->addRootEntityFromClassMetadata(Payment::class, 'p');
+
+        $rawQuery = sprintf(
+            'SELECT %s FROM %s p WHERE JSON_EXTRACT(details, \'$.paypal_order_id\') = ? LIMIT 0,1',
+            $builder->generateSelectClause(),
+            $this->entityManager->getClassMetadata(Payment::class)->getTableName()
+        );
+        /** @var NativeQuery $query */
+        $query = $this->entityManager->createNativeQuery($rawQuery, $builder);
+        $query->setParameter(1, $paypalOrderId);
+
+        return $query->getOneOrNullResult();
+    }
+
+}

--- a/src/Repository/PaymentRepositoryInterface.php
+++ b/src/Repository/PaymentRepositoryInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sylius\PayPalPlugin\Repository;
+
+interface PaymentRepositoryInterface
+{
+    public function getByPayPalOrderId(string $paypalOrderId);
+}

--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -84,12 +84,3 @@ monolog:
       type: stream
       path: '%kernel.logs_dir%/paypal.log'
       channels: [ paypal ]
-
-sylius_pay_pal:
-  webhooks:
-    -
-      route: 'sylius_paypal_plugin_webhook_checkout_order_approved'
-      event_types: [ 'CHECKOUT.ORDER.APPROVED' ]
-    -
-      route: 'sylius_paypal_plugin_webhook_payment_capture_completed'
-      event_types: [ 'PAYMENT.CAPTURE.COMPLETED' ]

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -62,7 +62,7 @@
             id="Sylius\PayPalPlugin\Provider\PaymentProviderInterface"
             class="Sylius\PayPalPlugin\Provider\PaymentProvider"
         >
-            <argument type="service" id="sylius.repository.payment" />
+            <argument type="service" id="Sylius\PayPalPlugin\Repository\PaymentRepositoryInterface" />
             <argument type="service" id="sylius.repository.order" />
         </service>
 
@@ -174,6 +174,14 @@
             decorates="Sylius\PayPalPlugin\Processor\PaymentRefundProcessorInterface"
         >
             <argument type="service" id="Sylius\PayPalPlugin\Processor\UiPayPalPaymentRefundProcessor.inner" />
+        </service>
+
+        <service
+                id="Sylius\PayPalPlugin\Repository\PaymentRepositoryInterface"
+                class="Sylius\PayPalPlugin\Repository\PaymentRepository"
+        >
+            <argument type="service" id="doctrine.orm.entity_manager" />
+            <argument type="service" id="sylius.repository.payment" />
         </service>
 
         <service

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -30,6 +30,17 @@
             <argument type="service" id="Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface" />
         </service>
 
+        <service id="Sylius\PayPalPlugin\Controller\Webhook\PaymentCaptureDeniedAction">
+            <argument type="service" id="sm.factory" />
+            <argument type="service" id="Sylius\PayPalPlugin\Provider\PaymentProviderInterface" />
+            <argument type="service" id="sylius.manager.payment" />
+            <argument type="service" id="Sylius\PayPalPlugin\Api\OrderDetailsApiInterface" />
+            <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalWebhookDataProviderInterface" />
+            <argument type="service" id="Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface" />
+            <argument type="service" id="sylius.order_payment_provider" />
+            <argument type="service" id="monolog.logger.paypal" />
+        </service>
+
         <service id="Sylius\PayPalPlugin\Controller\CancelPayPalOrderAction">
             <argument type="service" id="Sylius\PayPalPlugin\Provider\PaymentProviderInterface" />
             <argument type="service" id="sylius.repository.order" />

--- a/src/Resources/config/webhook.yml
+++ b/src/Resources/config/webhook.yml
@@ -3,6 +3,7 @@ sylius:
     webhooks:
       - route: 'sylius_paypal_plugin_webhook_checkout_order_approved'
         event_types: [ 'CHECKOUT.ORDER.APPROVED' ]
-          - route: 'sylius_paypal_plugin_webhook_payment_capture_completed'
-            event_types: [ 'PAYMENT.CAPTURE.COMPLETED' ]
-
+      - route: 'sylius_paypal_plugin_webhook_payment_capture_completed'
+        event_types: [ 'PAYMENT.CAPTURE.COMPLETED' ]
+      - route: 'sylius_paypal_plugin_webhook_payment_capture_denied'
+        event_types: [ 'PAYMENT.CAPTURE.DENIED' ]

--- a/src/Resources/config/webhook_routing.yaml
+++ b/src/Resources/config/webhook_routing.yaml
@@ -17,3 +17,10 @@ sylius_paypal_plugin_webhook_payment_capture_completed:
     methods: [POST]
     defaults:
         _controller: Sylius\PayPalPlugin\Controller\Webhook\PaymentCaptureCompletedAction
+
+# PAYMENT.CAPTURE.DENIED -> update state machine of order to STATE_CART and payment to TRANSITION_FAIL
+sylius_paypal_plugin_webhook_payment_capture_denied:
+    path: /paypal-webhook/payment_capture_denied
+    methods: [POST]
+    defaults:
+        _controller: Sylius\PayPalPlugin\Controller\Webhook\PaymentCaptureDeniedAction


### PR DESCRIPTION
Récupération du hook côté Paypal lors d'un refus de paiement : celui-ci repasse la commande au statut panier
https://ultrapremiumdirect.atlassian.net/browse/BACK-314?focusedCommentId=14527