### PR TITLE
fix: [BACK-629] Paypal - Commandes restées bloquées en attente de paiement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "sylius/sylius": "^1.10",
         "phpseclib/phpseclib": "^2.0",
         "sylius-labs/doctrine-migrations-extra-bundle": "^0.1.3",
-        "doctrine/doctrine-migrations-bundle": "^3.0"
+        "doctrine/doctrine-migrations-bundle": "^3.0",
+        "symfony/property-access": "^5.2"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",
@@ -75,5 +76,12 @@
         "link-templates": [
             "ln -s $(pwd)/src/Resources/views/bundles/* $(pwd)/tests/Application/templates/bundles"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": false,
+            "symfony/thanks": false,
+            "dealerdirect/phpcodesniffer-composer-installer": false
+        }
     }
 }

--- a/src/Api/CreateOrderApi.php
+++ b/src/Api/CreateOrderApi.php
@@ -74,7 +74,8 @@ final class CreateOrderApi implements CreateOrderApiInterface
 
         $payPalPurchaseUnit = new PayPalPurchaseUnit(
             $referenceId,
-            $this->paymentReferenceNumberProvider->provide($payment),
+            (int)$order->getId(),
+            (string)$order->getNumber(),
             (string)$order->getCurrencyCode(),
             (int)$payment->getAmount(),
             $order->getShippingTotal(),

--- a/src/Api/UpdateOrderApi.php
+++ b/src/Api/UpdateOrderApi.php
@@ -55,7 +55,8 @@ final class UpdateOrderApi implements UpdateOrderApiInterface
 
         $data = new PayPalPurchaseUnit(
             $referenceId,
-            $this->paymentReferenceNumberProvider->provide($payment),
+            (int)$order->getId(),
+            (string)$order->getNumber(),
             (string) $order->getCurrencyCode(),
             (int) $payment->getAmount(),
             $order->getShippingTotal(),

--- a/src/Command/CheckAwaitingPaymentCommand.php
+++ b/src/Command/CheckAwaitingPaymentCommand.php
@@ -249,11 +249,11 @@ final class CheckAwaitingPaymentCommand extends Command
     {
         /** @var string|null $errorName */
         $errorName = $this->accessor->getValue($err, '[name]');
-        if (in_array($errorName, ['UNPROCESSABLE_ENTITY'])) {
+        if ($errorName === 'UNPROCESSABLE_ENTITY') {
             if (!$this->isDry) {
                 // Log error in payment details
                 $payment->setDetails(array_merge($payment->getDetails(), [
-                    'status' => 'FAILED',
+                    'status' => StatusAction::STATE_FAILED,
                     'error' => $err
                 ]));
 

--- a/src/Controller/Webhook/AbstractWebhookAction.php
+++ b/src/Controller/Webhook/AbstractWebhookAction.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Controller\Webhook;
+
+use GuzzleHttp\Exception\RequestException;
+use Monolog\Logger;
+use SM\SMException;
+use Sylius\PayPalPlugin\Exception\PayPalWrongDataException;
+use Sylius\PayPalPlugin\Provider\PayPalWebhookDataProviderInterface;
+use Sylius\PayPalPlugin\Service\WebhookService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Webmozart\Assert\Assert;
+
+abstract class AbstractWebhookAction implements WebhookActionInterface
+{
+    protected string $webhookEvent = '';
+    private WebhookService $webhookService;
+    private PayPalWebhookDataProviderInterface $payPalWebhookDataProvider;
+    private Logger $logger;
+
+    public function __construct(
+        WebhookService                     $webhookService,
+        PayPalWebhookDataProviderInterface $payPalWebhookDataProvider,
+        Logger                             $logger
+    )
+    {
+        $this->webhookService = $webhookService;
+        $this->payPalWebhookDataProvider = $payPalWebhookDataProvider;
+        $this->logger = $logger;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        if ($this->supports($request)) {
+            try {
+                $data = $this->payPalWebhookDataProvider->provide(
+                    $this->getPayPalPaymentUrl($request),
+                    $this->getRelWebhookDataProvider()
+                );
+                $this->webhookService->handlePaypalOrder((string)$data['id']);
+
+            } catch (RequestException|PayPalWrongDataException|SMException $exception) {
+                $this->logger->debug('[' . $this->webhookEvent . '] error: ' . $exception->getMessage());
+                return new JsonResponse(['error' => $exception->getMessage()], Response::HTTP_BAD_REQUEST);
+            }
+
+            return new JsonResponse([], Response::HTTP_OK);
+        }
+
+        return new JsonResponse([], Response::HTTP_BAD_REQUEST);
+    }
+
+    public function supports(Request $request): bool
+    {
+        Assert::notEmpty($this->webhookEvent, 'Paypal webhookEvent can not be empty');
+        $content = (array)json_decode((string)$request->getContent(false), true);
+        Assert::keyExists($content, 'event_type');
+
+        return ($content['event_type'] === $this->webhookEvent);
+    }
+
+    /**
+     * @param Request $request
+     * @return string
+     * @throws PayPalWrongDataException
+     */
+    public function getPayPalPaymentUrl(Request $request): string
+    {
+        $content = (array)json_decode((string)$request->getContent(false), true);
+        Assert::keyExists($content, 'resource');
+        $resource = (array)$content['resource'];
+        Assert::keyExists($resource, 'links');
+
+        /** @var string[] $link */
+        foreach ($resource['links'] as $link) {
+            if ($link['rel'] === 'self') {
+                return (string)$link['href'];
+            }
+        }
+
+        throw new PayPalWrongDataException();
+    }
+
+    /**
+     * @return string
+     */
+    public function getRelWebhookDataProvider(): string
+    {
+        return 'up';
+    }
+}

--- a/src/Controller/Webhook/CheckoutOrderApprovedAction.php
+++ b/src/Controller/Webhook/CheckoutOrderApprovedAction.php
@@ -4,172 +4,35 @@ declare(strict_types=1);
 
 namespace Sylius\PayPalPlugin\Controller\Webhook;
 
-use Doctrine\Persistence\ObjectManager;
-use GuzzleHttp\Exception\RequestException;
 use Monolog\Logger;
-use SM\Factory\FactoryInterface;
-use Sylius\Component\Core\Model\PaymentInterface;
-use Sylius\Component\Core\Model\PaymentMethodInterface;
-use Sylius\Component\Order\StateResolver\StateResolverInterface;
-use Sylius\Component\Payment\PaymentTransitions;
-use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
-use Sylius\PayPalPlugin\Api\CompleteOrderApiInterface;
-use Sylius\PayPalPlugin\Api\OrderDetailsApiInterface;
-use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
-use Sylius\PayPalPlugin\Exception\PayPalWrongDataException;
-use Sylius\PayPalPlugin\Payum\Action\StatusAction;
-use Sylius\PayPalPlugin\Provider\PaymentProviderInterface;
 use Sylius\PayPalPlugin\Provider\PayPalWebhookDataProviderInterface;
-use Sylius\PayPalPlugin\Updater\PaymentUpdaterInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Sylius\PayPalPlugin\Service\WebhookService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Webmozart\Assert\Assert;
 
-final class CheckoutOrderApprovedAction
+final class CheckoutOrderApprovedAction extends AbstractWebhookAction
 {
-    const WEBHOOK_EVENT = 'CHECKOUT.ORDER.APPROVED';
-
-    private FactoryInterface $stateMachineFactory;
-    private PaymentProviderInterface $paymentProvider;
-    private ObjectManager $paymentManager;
-    private OrderDetailsApiInterface $orderDetailsApi;
-    private PayPalWebhookDataProviderInterface $payPalWebhookDataProvider;
-    private CacheAuthorizeClientApiInterface $authorizeClientApi;
-    private CompleteOrderApiInterface $completeOrderApi;
-    private PaymentUpdaterInterface $payPalPaymentUpdater;
-    private StateResolverInterface $orderPaymentStateResolver;
-    private Logger $logger;
+    protected string $webhookEvent = 'CHECKOUT.ORDER.APPROVED';
 
     public function __construct(
-        FactoryInterface                   $stateMachineFactory,
-        PaymentProviderInterface           $paymentProvider,
-        ObjectManager                      $paymentManager,
-        OrderDetailsApiInterface           $orderDetailsApi,
+        WebhookService $webhookService,
         PayPalWebhookDataProviderInterface $payPalWebhookDataProvider,
-        CacheAuthorizeClientApiInterface   $authorizeClientApi,
-        CompleteOrderApiInterface          $completeOrderApi,
-        PaymentUpdaterInterface            $payPalPaymentUpdater,
-        StateResolverInterface             $orderPaymentStateResolver,
-        Logger                             $logger
+        Logger $logger
     )
     {
-        $this->stateMachineFactory = $stateMachineFactory;
-        $this->paymentProvider = $paymentProvider;
-        $this->paymentManager = $paymentManager;
-        $this->orderDetailsApi = $orderDetailsApi;
-        $this->payPalWebhookDataProvider = $payPalWebhookDataProvider;
-        $this->authorizeClientApi = $authorizeClientApi;
-        $this->completeOrderApi = $completeOrderApi;
-        $this->payPalPaymentUpdater = $payPalPaymentUpdater;
-        $this->orderPaymentStateResolver = $orderPaymentStateResolver;
-        $this->logger = $logger;
+        parent::__construct($webhookService, $payPalWebhookDataProvider, $logger);
     }
 
     public function __invoke(Request $request): Response
     {
-        if ($this->supports($request)) {
-            try {
-                $data = $this->payPalWebhookDataProvider->provide($this->getPayPalPaymentUrl($request), 'self');
-
-                try {
-                    /** @var PaymentInterface $payment */
-                    $payment = $this->paymentProvider->getByPayPalOrderId((string)$data['id']);
-                } catch (PaymentNotFoundException $exception) {
-                    return new JsonResponse(['error' => $exception->getMessage()], Response::HTTP_NOT_FOUND);
-                }
-
-                if ($payment->getDetails()['status'] === StatusAction::STATUS_CREATED) {
-                    /** @var PaymentMethodInterface $paymentMethod */
-                    $paymentMethod = $payment->getMethod();
-                    $token = $this->authorizeClientApi->authorize($paymentMethod);
-
-                    // Capture order to complete it
-                    $detailsComplete = $this->completeOrderApi->complete($token, $data['id']);
-
-                    // Retrieve order details
-                    $details = $this->orderDetailsApi->get($token, $data['id']);
-
-                    $order = $payment->getOrder();
-                    $totalPaypal = (int) round($details['purchase_units'][0]['amount']['value'] * 100);
-
-                    // Update payment total with the Paypal total (partially paid state will be triggered)
-                    if ($totalPaypal != $order->getTotal()) {
-                        $this->payPalPaymentUpdater->updateAmount($payment, $totalPaypal);
-                        $this->orderPaymentStateResolver->resolve($order);
-                    }
-
-                    if ($this->getDetailsStatus($details)) {
-                        $detailsPayment = array_merge($payment->getDetails(), [
-                            'status' => $details['status'] === 'COMPLETED' ? StatusAction::STATUS_COMPLETED : StatusAction::STATUS_PROCESSING,
-                            'paypal_order_details' => $details
-                        ]);
-
-                        if ($this->getDetailsStatus($detailsComplete) === 'COMPLETED') {
-                            $detailsPayment['transaction_id'] = $details['purchase_units'][0]['payments']['captures'][0]['id'];
-                        }
-
-                        $payment->setDetails($detailsPayment);
-                        $stateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
-
-                        switch ($details['status']) {
-                            case 'COMPLETED':
-                                if ($stateMachine->can(PaymentTransitions::TRANSITION_COMPLETE)) {
-                                    $stateMachine->apply(PaymentTransitions::TRANSITION_COMPLETE);
-                                }
-                                break;
-                            case 'PROCESSING':
-                                if ($stateMachine->can(PaymentTransitions::TRANSITION_PROCESS)) {
-                                    $stateMachine->apply(PaymentTransitions::TRANSITION_PROCESS);
-                                }
-                                break;
-                            default: // No implementation explicit
-                                break;
-                        }
-
-                        $this->paymentManager->flush();
-                    }
-                }
-            } catch (RequestException $requestException) {
-                $this->logger->debug('error: ' . $requestException->getMessage());
-                return new JsonResponse(['error' => $requestException->getMessage()], Response::HTTP_BAD_REQUEST);
-            }
-
-            return new JsonResponse([], Response::HTTP_OK);
-        }
-
-        return new JsonResponse([], Response::HTTP_BAD_REQUEST);
+        return parent::__invoke($request);
     }
 
-    public function supports(Request $request): bool
+    /**
+     * @return string
+     */
+    public function getRelWebhookDataProvider(): string
     {
-        $content = (array)json_decode((string)$request->getContent(false), true);
-        Assert::keyExists($content, 'event_type');
-
-        return ($content['event_type'] === self::WEBHOOK_EVENT);
-    }
-
-    private function getPayPalPaymentUrl(Request $request): string
-    {
-        $content = (array)json_decode((string)$request->getContent(false), true);
-        Assert::keyExists($content, 'resource');
-        $resource = (array)$content['resource'];
-        Assert::keyExists($resource, 'links');
-
-        /** @var string[] $link */
-        foreach ($resource['links'] as $link) {
-            if ($link['rel'] === 'self') {
-                return (string)$link['href'];
-            }
-        }
-
-        throw new PayPalWrongDataException();
-    }
-
-    private function getDetailsStatus($orderDetails)
-    {
-        if (!isset($orderDetails['status']))
-            return false;
-        return $orderDetails['status'];
+        return 'self';
     }
 }

--- a/src/Controller/Webhook/PaymentCaptureCompletedAction.php
+++ b/src/Controller/Webhook/PaymentCaptureCompletedAction.php
@@ -4,138 +4,27 @@ declare(strict_types=1);
 
 namespace Sylius\PayPalPlugin\Controller\Webhook;
 
-use Doctrine\Persistence\ObjectManager;
-use GuzzleHttp\Exception\RequestException;
-use Payum\Core\Action\ActionInterface;
-use SM\Factory\FactoryInterface;
-use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\Model\PaymentInterface;
-use Sylius\Component\Core\Model\PaymentMethodInterface;
-use Sylius\Component\Core\OrderCheckoutTransitions;
-use Sylius\Component\Payment\PaymentTransitions;
-use Sylius\Component\Resource\StateMachine\StateMachineInterface;
-use Sylius\PayPalPlugin\Api\AuthorizeClientApiInterface;
-use Sylius\PayPalPlugin\Api\AuthorizePaymentOrderApiInterface;
-use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
-use Sylius\PayPalPlugin\Api\CompleteOrderApiInterface;
-use Sylius\PayPalPlugin\Api\OrderDetailsApiInterface;
-use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
-use Sylius\PayPalPlugin\Exception\PayPalWrongDataException;
-use Sylius\PayPalPlugin\Exception\PayPalWrongWebhookException;
-use Sylius\PayPalPlugin\Payum\Action\StatusAction;
-use Sylius\PayPalPlugin\Provider\PaymentProviderInterface;
+use Monolog\Logger;
 use Sylius\PayPalPlugin\Provider\PayPalWebhookDataProviderInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Sylius\PayPalPlugin\Service\WebhookService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Webmozart\Assert\Assert;
 
-final class PaymentCaptureCompletedAction
+final class PaymentCaptureCompletedAction extends AbstractWebhookAction
 {
-    const WEBHOOK_EVENT = 'PAYMENT.CAPTURE.COMPLETED';
-
-    private FactoryInterface $stateMachineFactory;
-    private PaymentProviderInterface $paymentProvider;
-    private ObjectManager $paymentManager;
-    private OrderDetailsApiInterface $orderDetailsApi;
-    private PayPalWebhookDataProviderInterface $payPalWebhookDataProvider;
-    private CacheAuthorizeClientApiInterface $authorizeClientApi;
+    protected string $webhookEvent = 'PAYMENT.CAPTURE.COMPLETED';
 
     public function __construct(
-        FactoryInterface                   $stateMachineFactory,
-        PaymentProviderInterface           $paymentProvider,
-        ObjectManager                      $paymentManager,
-        OrderDetailsApiInterface           $orderDetailsApi,
+        WebhookService $webhookService,
         PayPalWebhookDataProviderInterface $payPalWebhookDataProvider,
-        CacheAuthorizeClientApiInterface   $authorizeClientApi
+        Logger $logger
     )
     {
-        $this->stateMachineFactory = $stateMachineFactory;
-        $this->paymentProvider = $paymentProvider;
-        $this->paymentManager = $paymentManager;
-        $this->orderDetailsApi = $orderDetailsApi;
-        $this->payPalWebhookDataProvider = $payPalWebhookDataProvider;
-        $this->authorizeClientApi = $authorizeClientApi;
+        parent::__construct($webhookService, $payPalWebhookDataProvider, $logger);
     }
 
     public function __invoke(Request $request): Response
     {
-        if ($this->supports($request)) {
-            try {
-                $data = $this->payPalWebhookDataProvider->provide($this->getPayPalPaymentUrl($request), 'up');
-
-                try {
-                    /** @var PaymentInterface $payment */
-                    $payment = $this->paymentProvider->getByPayPalOrderId((string)$data['id']);
-                    /** @var OrderInterface $order */
-                    $order = $payment->getOrder();
-
-                } catch (PaymentNotFoundException $exception) {
-                    return new JsonResponse(['error' => $exception->getMessage()], Response::HTTP_NOT_FOUND);
-                }
-
-                /** @var PaymentMethodInterface $paymentMethod */
-                $paymentMethod = $payment->getMethod();
-                $token = $this->authorizeClientApi->authorize($paymentMethod);
-
-                // Retrieve order details
-                $details = $this->orderDetailsApi->get($token, $data['id']);
-                if ($this->getDetailsStatus($details) === 'COMPLETED') {
-                    $stateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
-
-                    if ($stateMachine->can(PaymentTransitions::TRANSITION_COMPLETE)) {
-                        $stateMachine->apply(PaymentTransitions::TRANSITION_COMPLETE);
-                    }
-
-                    $stateMachine = $this->stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH);
-                    if ($stateMachine->can(OrderCheckoutTransitions::TRANSITION_COMPLETE)) {
-                        $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_COMPLETE);
-                    }
-
-                    $paymentDetails = $payment->getDetails();
-                    $paymentDetails['status'] = StatusAction::STATUS_COMPLETED;
-
-                    $payment->setDetails($paymentDetails);
-                }
-
-                $this->paymentManager->flush();
-            } catch (RequestException $requestException) {
-                return new JsonResponse(['error' => $requestException->getMessage()], Response::HTTP_BAD_REQUEST);
-            }
-        }
-
-        return new JsonResponse([], Response::HTTP_OK);
-    }
-
-    public function supports(Request $request): bool
-    {
-        $content = (array)json_decode((string)$request->getContent(false), true);
-        Assert::keyExists($content, 'event_type');
-
-        return ($content['event_type'] === self::WEBHOOK_EVENT);
-    }
-
-    private function getPayPalPaymentUrl(Request $request): string
-    {
-        $content = (array)json_decode((string)$request->getContent(false), true);
-        Assert::keyExists($content, 'resource');
-        $resource = (array)$content['resource'];
-        Assert::keyExists($resource, 'links');
-
-        /** @var string[] $link */
-        foreach ($resource['links'] as $link) {
-            if ($link['rel'] === 'self') {
-                return (string)$link['href'];
-            }
-        }
-
-        throw new PayPalWrongDataException();
-    }
-
-    private function getDetailsStatus($orderDetails)
-    {
-        if (!isset($orderDetails['status']))
-            return false;
-        return $orderDetails['status'];
+        return parent::__invoke($request);
     }
 }

--- a/src/Controller/Webhook/PaymentCaptureDeniedAction.php
+++ b/src/Controller/Webhook/PaymentCaptureDeniedAction.php
@@ -1,145 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sylius\PayPalPlugin\Controller\Webhook;
 
-use Doctrine\Persistence\ObjectManager;
-use GuzzleHttp\Exception\RequestException;
 use Monolog\Logger;
-use SM\Factory\FactoryInterface;
-use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\Model\PaymentInterface;
-use Sylius\Component\Core\Model\PaymentMethodInterface;
-use Sylius\Component\Core\Payment\Provider\OrderPaymentProviderInterface;
-use Sylius\Component\Payment\Model\PaymentInterface as PaymentInterfaceAlias;
-use Sylius\Component\Payment\PaymentTransitions;
-use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
-use Sylius\PayPalPlugin\Api\OrderDetailsApiInterface;
-use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
-use Sylius\PayPalPlugin\Exception\PayPalWrongDataException;
-use Sylius\PayPalPlugin\Payum\Action\StatusAction;
-use Sylius\PayPalPlugin\Provider\PaymentProviderInterface;
 use Sylius\PayPalPlugin\Provider\PayPalWebhookDataProviderInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Sylius\PayPalPlugin\Service\WebhookService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Webmozart\Assert\Assert;
 
-final class PaymentCaptureDeniedAction
+final class PaymentCaptureDeniedAction extends AbstractWebhookAction
 {
-    const WEBHOOK_EVENT = 'PAYMENT.CAPTURE.DENIED';
-
-    private FactoryInterface $stateMachineFactory;
-    private PaymentProviderInterface $paymentProvider;
-    private ObjectManager $paymentManager;
-    private OrderDetailsApiInterface $orderDetailsApi;
-    private PayPalWebhookDataProviderInterface $payPalWebhookDataProvider;
-    private CacheAuthorizeClientApiInterface $authorizeClientApi;
-    private OrderPaymentProviderInterface $orderPaymentProvider;
-    private Logger $logger;
+    protected string $webhookEvent = 'PAYMENT.CAPTURE.DENIED';
 
     public function __construct(
-        FactoryInterface                   $stateMachineFactory,
-        PaymentProviderInterface           $paymentProvider,
-        ObjectManager                      $paymentManager,
-        OrderDetailsApiInterface           $orderDetailsApi,
+        WebhookService $webhookService,
         PayPalWebhookDataProviderInterface $payPalWebhookDataProvider,
-        CacheAuthorizeClientApiInterface   $authorizeClientApi,
-        OrderPaymentProviderInterface  $orderPaymentProvider,
         Logger $logger
     )
     {
-        $this->stateMachineFactory = $stateMachineFactory;
-        $this->paymentProvider = $paymentProvider;
-        $this->paymentManager = $paymentManager;
-        $this->orderDetailsApi = $orderDetailsApi;
-        $this->payPalWebhookDataProvider = $payPalWebhookDataProvider;
-        $this->authorizeClientApi = $authorizeClientApi;
-        $this->orderPaymentProvider = $orderPaymentProvider;
-        $this->logger = $logger;
+        parent::__construct($webhookService, $payPalWebhookDataProvider, $logger);
     }
 
     public function __invoke(Request $request): Response
     {
-        if ($this->supports($request)) {
-            try {
-                $data = $this->payPalWebhookDataProvider->provide($this->getPayPalPaymentUrl($request), 'up');
-
-                try {
-                    /** @var PaymentInterface $payment */
-                    $payment = $this->paymentProvider->getByPayPalOrderId((string)$data['id']);
-
-                    /** @var OrderInterface $order */
-                    $order = $payment->getOrder();
-
-                } catch (PaymentNotFoundException $exception) {
-                    return new JsonResponse(['error' => $exception->getMessage()], Response::HTTP_NOT_FOUND);
-                }
-
-                /** @var PaymentMethodInterface $paymentMethod */
-                $paymentMethod = $payment->getMethod();
-                $token = $this->authorizeClientApi->authorize($paymentMethod);
-
-                // Retrieve order details
-                $details = $this->orderDetailsApi->get($token, $data['id']);
-
-                if ($this->getDetailsStatus($details) === 'DECLINED') {
-                    $stateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
-                    if ($stateMachine->can(PaymentTransitions::TRANSITION_PROCESS)) {
-                        $stateMachine->apply(PaymentTransitions::TRANSITION_PROCESS);
-                    }
-
-                    $stateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
-                    if ($stateMachine->can(PaymentTransitions::TRANSITION_FAIL)) {
-                        $stateMachine->apply(PaymentTransitions::TRANSITION_FAIL);
-                    }
-
-                    $newPayment = $this->orderPaymentProvider->provideOrderPayment($order, PaymentInterfaceAlias::STATE_CART);
-                    if($newPayment) {
-                        $order->addPayment($newPayment);
-                    }
-                }
-
-                $this->paymentManager->flush();
-            } catch (RequestException $requestException) {
-                $this->logger->error($requestException->getMessage());
-                return new JsonResponse(['error' => $requestException->getMessage()], Response::HTTP_BAD_REQUEST);
-            }
-
-            return new JsonResponse([], Response::HTTP_OK);
-        }
-
-        return new JsonResponse([], Response::HTTP_BAD_REQUEST);
-    }
-
-    public function supports(Request $request): bool
-    {
-        $content = (array)json_decode((string)$request->getContent(false), true);
-        Assert::keyExists($content, 'event_type');
-
-        return ($content['event_type'] === self::WEBHOOK_EVENT);
-    }
-
-    private function getPayPalPaymentUrl(Request $request): string
-    {
-        $content = (array)json_decode((string)$request->getContent(false), true);
-        Assert::keyExists($content, 'resource');
-        $resource = (array)$content['resource'];
-        Assert::keyExists($resource, 'links');
-
-        /** @var string[] $link */
-        foreach ($resource['links'] as $link) {
-            if ($link['rel'] === 'self') {
-                return (string)$link['href'];
-            }
-        }
-
-        throw new PayPalWrongDataException();
-    }
-
-    private function getDetailsStatus($orderDetails)
-    {
-        if (!isset($orderDetails['status']))
-            return false;
-        return $orderDetails['status'];
+        return parent::__invoke($request);
     }
 }

--- a/src/Controller/Webhook/WebhookActionInterface.php
+++ b/src/Controller/Webhook/WebhookActionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sylius\PayPalPlugin\Controller\Webhook;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface WebhookActionInterface
+{
+    public function supports(Request $request): bool;
+    public function getPayPalPaymentUrl(Request $request): string;
+}

--- a/src/Model/PayPalPurchaseUnit.php
+++ b/src/Model/PayPalPurchaseUnit.php
@@ -22,7 +22,10 @@ class PayPalPurchaseUnit
     private $referenceId;
 
     /** @var string */
-    private $invoiceNumber;
+    private $customId;
+
+    /** @var int */
+    private $invoiceId;
 
     /** @var string */
     private $currencyCode;
@@ -59,7 +62,8 @@ class PayPalPurchaseUnit
 
     public function __construct(
         string $referenceId,
-        string $invoiceNumber,
+        int $customId,
+        string $invoiceId,
         string $currencyCode,
         int $totalAmount,
         int $shippingValue,
@@ -73,7 +77,8 @@ class PayPalPurchaseUnit
         string $softDescriptor = 'Sylius PayPal Payment'
     ) {
         $this->referenceId = $referenceId;
-        $this->invoiceNumber = $invoiceNumber;
+        $this->customId = $customId;
+        $this->invoiceId = $invoiceId;
         $this->currencyCode = $currencyCode;
         $this->totalAmount = $totalAmount;
         $this->shippingValue = $shippingValue;
@@ -91,7 +96,8 @@ class PayPalPurchaseUnit
     {
         $paypalPurchaseUnit = [
             'reference_id' => $this->referenceId,
-            'invoice_number' => $this->invoiceNumber,
+            'custom_id' => $this->customId,
+            'invoice_id' => $this->invoiceId,
             'amount' => [
                 'currency_code' => $this->currencyCode,
                 'value' => number_format($this->totalAmount / 100, 2, '.', ''),

--- a/src/Payum/Action/StatusAction.php
+++ b/src/Payum/Action/StatusAction.php
@@ -28,6 +28,8 @@ final class StatusAction implements ActionInterface
 
     public const STATUS_PROCESSING = 'PROCESSING';
 
+    public const STATE_FAILED = 'FAILED';
+
     /** @param GetStatus $request */
     public function execute($request): void
     {

--- a/src/Provider/PayPalWebhookDataProvider.php
+++ b/src/Provider/PayPalWebhookDataProvider.php
@@ -25,6 +25,13 @@ final class PayPalWebhookDataProvider implements PayPalWebhookDataProviderInterf
         $this->payPalPaymentMethodProvider = $payPalPaymentMethodProvider;
     }
 
+    /**
+     * @param string $url
+     * @param string $rel
+     * @return array
+     * @throws PayPalWrongDataException
+     * @throws \Sylius\PayPalPlugin\Exception\PayPalPaymentMethodNotFoundException
+     */
     public function provide(string $url, string $rel): array
     {
         $paymentMethod = $this->payPalPaymentMethodProvider->provide();

--- a/src/Provider/PaymentProvider.php
+++ b/src/Provider/PaymentProvider.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Repository\PaymentRepositoryInterface;
+use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
 
 final class PaymentProvider implements PaymentProviderInterface
 {
@@ -29,7 +30,13 @@ final class PaymentProvider implements PaymentProviderInterface
         $this->paymentRepository = $paymentRepository;
     }
 
-    public function getByPayPalOrderId(string $orderId): PaymentInterface
+    /**
+     * @param string $orderId
+     * @return PaymentInterface|null
+     * @throws PaymentNotFoundException
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    public function getByPayPalOrderId(string $orderId): ?PaymentInterface
     {
         /** @var ResultSetMappingBuilder $builder */
         $builder = $this->paymentRepository->createResultSetMappingBuilder('p');
@@ -48,7 +55,12 @@ final class PaymentProvider implements PaymentProviderInterface
 
         $query = $this->entityManager->createNativeQuery($rawQuery, $builder);
         $query->setParameter(1, $orderId);
+        $payment = $query->getOneOrNullResult();
 
-        return $query->getOneOrNullResult();
+        if (!is_null($payment)) {
+            return $payment;
+        }
+
+        throw PaymentNotFoundException::withPayPalOrderId($orderId);
     }
 }

--- a/src/Provider/PaymentProviderInterface.php
+++ b/src/Provider/PaymentProviderInterface.php
@@ -9,6 +9,10 @@ use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
 
 interface PaymentProviderInterface
 {
-    /** @throws PaymentNotFoundException */
-    public function getByPayPalOrderId(string $orderId): PaymentInterface;
+    /**
+     * @param string $orderId
+     * @return null|PaymentInterface
+     * @throws PaymentNotFoundException
+     */
+    public function getByPayPalOrderId(string $orderId): ?PaymentInterface;
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -284,5 +284,14 @@
         <service id="Sylius\PayPalPlugin\Twig\OrderAddressExtension">
             <tag name="twig.extension" />
         </service>
+
+        <service id="Sylius\PayPalPlugin\Service\WebhookService">
+            <argument type="service" id="sm.factory" />
+            <argument type="service" id="Sylius\PayPalPlugin\Provider\PaymentProviderInterface" />
+            <argument type="service" id="sylius.manager.payment" />
+            <argument type="service" id="Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface" />
+            <argument type="service" id="Sylius\PayPalPlugin\Api\CompleteOrderApiInterface" />
+            <argument type="service" id="Sylius\PayPalPlugin\Api\OrderDetailsApiInterface" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -12,35 +12,20 @@
         </service>
 
         <service id="Sylius\PayPalPlugin\Controller\Webhook\CheckoutOrderApprovedAction">
-            <argument type="service" id="sm.factory" />
-            <argument type="service" id="Sylius\PayPalPlugin\Provider\PaymentProviderInterface" />
-            <argument type="service" id="sylius.manager.payment" />
-            <argument type="service" id="Sylius\PayPalPlugin\Api\OrderDetailsApiInterface" />
+            <argument type="service" id="Sylius\PayPalPlugin\Service\WebhookService" />
             <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalWebhookDataProviderInterface" />
-            <argument type="service" id="Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface" />
-            <argument type="service" id="Sylius\PayPalPlugin\Api\CompleteOrderApiInterface" />
-            <argument type="service" id="Sylius\PayPalPlugin\Updater\PaymentUpdaterInterface" />
-            <argument type="service" id="sylius.state_resolver.order_payment" />
             <argument type="service" id="monolog.logger.paypal" />
         </service>
 
         <service id="Sylius\PayPalPlugin\Controller\Webhook\PaymentCaptureCompletedAction">
-            <argument type="service" id="sm.factory" />
-            <argument type="service" id="Sylius\PayPalPlugin\Provider\PaymentProviderInterface" />
-            <argument type="service" id="sylius.manager.payment" />
-            <argument type="service" id="Sylius\PayPalPlugin\Api\OrderDetailsApiInterface" />
+            <argument type="service" id="Sylius\PayPalPlugin\Service\WebhookService" />
             <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalWebhookDataProviderInterface" />
-            <argument type="service" id="Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface" />
+            <argument type="service" id="monolog.logger.paypal" />
         </service>
 
         <service id="Sylius\PayPalPlugin\Controller\Webhook\PaymentCaptureDeniedAction">
-            <argument type="service" id="sm.factory" />
-            <argument type="service" id="Sylius\PayPalPlugin\Provider\PaymentProviderInterface" />
-            <argument type="service" id="sylius.manager.payment" />
-            <argument type="service" id="Sylius\PayPalPlugin\Api\OrderDetailsApiInterface" />
+            <argument type="service" id="Sylius\PayPalPlugin\Service\WebhookService" />
             <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalWebhookDataProviderInterface" />
-            <argument type="service" id="Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface" />
-            <argument type="service" id="sylius.order_payment_provider" />
             <argument type="service" id="monolog.logger.paypal" />
         </service>
 

--- a/src/Service/WebhookService.php
+++ b/src/Service/WebhookService.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Sylius\PayPalPlugin\Service;
+
+use Doctrine\Persistence\ObjectManager;
+use SM\Factory\FactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
+use Sylius\Component\Payment\Model\PaymentInterface as PaymentInterfaceAlias;
+use Sylius\Component\Payment\PaymentTransitions;
+use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
+use Sylius\PayPalPlugin\Api\CompleteOrderApiInterface;
+use Sylius\PayPalPlugin\Api\OrderDetailsApiInterface;
+use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
+use Sylius\PayPalPlugin\Payum\Action\StatusAction;
+use Sylius\PayPalPlugin\Provider\PaymentProviderInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+
+class WebhookService
+{
+    const INSTRUMENT_DECLINED = 'INSTRUMENT_DECLINED';
+    const PAYER_ACTION_REQUIRED = 'PAYER_ACTION_REQUIRED';
+    const DUPLICATE_INVOICE_ID = 'DUPLICATE_INVOICE_ID';
+
+    private FactoryInterface $stateMachineFactory;
+    private PaymentProviderInterface $paymentProvider;
+    private ObjectManager $paymentManager;
+    private CacheAuthorizeClientApiInterface $authorizeClientApi;
+    private CompleteOrderApiInterface $completeOrderApi;
+    private OrderDetailsApiInterface $orderDetailsApi;
+    private PropertyAccessor $propertyAccessor;
+
+    public function __construct(
+        FactoryInterface                 $stateMachineFactory,
+        PaymentProviderInterface         $paymentProvider,
+        ObjectManager                    $paymentManager,
+        CacheAuthorizeClientApiInterface $authorizeClientApi,
+        CompleteOrderApiInterface        $completeOrderApi,
+        OrderDetailsApiInterface         $orderDetailsApi
+    )
+    {
+        $this->stateMachineFactory = $stateMachineFactory;
+        $this->paymentProvider = $paymentProvider;
+        $this->paymentManager = $paymentManager;
+        $this->authorizeClientApi = $authorizeClientApi;
+        $this->completeOrderApi = $completeOrderApi;
+        $this->orderDetailsApi = $orderDetailsApi;
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+    }
+
+    /**
+     * @param string $paypalOrderID
+     * @param string $payerId
+     * @return bool
+     */
+    public function isValidPaypalOrder(string $paypalOrderID, string $payerId): bool
+    {
+        try {
+            $payment = $this->paymentProvider->getByPayPalOrderId($paypalOrderID);
+        } catch (PaymentNotFoundException $e) {
+            unset($e);
+            return false;
+        }
+
+        /** @var PaymentMethodInterface $paymentMethod */
+        $paymentMethod = $payment->getMethod();
+        $token = $this->authorizeClientApi->authorize($paymentMethod);
+
+        // Retrieve order details
+        $details = $this->orderDetailsApi->get($token, $paypalOrderID);
+
+        return $this->propertyAccessor->getValue($details, '[payer][payer_id]') === $payerId;
+    }
+
+    /**
+     * @param string $paypalOrderID
+     * @return void
+     * @throws \SM\SMException
+     */
+    public function handlePaypalOrder(string $paypalOrderID): void
+    {
+        try {
+            $payment = $this->paymentProvider->getByPayPalOrderId($paypalOrderID);
+        } catch (PaymentNotFoundException $e) {
+            unset($e);
+            return;
+        }
+
+        if (!is_null($payment) && isset($payment->getDetails()['status'])
+            && in_array($payment->getDetails()['status'], [StatusAction::STATUS_CREATED, StatusAction::STATUS_PROCESSING])
+            && in_array($payment->getState(), [PaymentInterfaceAlias::STATE_NEW, PaymentInterfaceAlias::STATE_PROCESSING])
+        ) {
+            /** @var OrderInterface $order */
+            $order = $payment->getOrder();
+
+            // Try to complete Order if not
+            $stateMachine = $this->stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH);
+            if ($stateMachine->can(OrderCheckoutTransitions::TRANSITION_COMPLETE)) {
+                $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_COMPLETE);
+            }
+
+            /** @var PaymentMethodInterface $paymentMethod */
+            $paymentMethod = $payment->getMethod();
+            $token = $this->authorizeClientApi->authorize($paymentMethod);
+
+            // Retrieve Paypal order details
+            $details = $this->orderDetailsApi->get($token, $paypalOrderID);
+
+            switch ($this->propertyAccessor->getValue($details, '[status]')) {
+                case 'APPROVED':
+                    $this->_captureOrder($paypalOrderID, $payment, $token);
+                    break;
+                case 'COMPLETED':
+                    $this->_markOrderStatus($details, $payment, StatusAction::STATUS_COMPLETED);
+                    break;
+                default:
+                    $this->_markOrderStatus($details, $payment, StatusAction::STATUS_PROCESSING);
+                    break;
+            }
+        }
+    }
+
+    /**
+     * @param string $paypalOrderID
+     * @param PaymentInterface $payment
+     * @param string $token
+     * @return void
+     */
+    private function _captureOrder(string $paypalOrderID, PaymentInterface $payment, string $token): void
+    {
+        // Call to capture Paypal order
+        $detailsComplete = $this->completeOrderApi->complete($token, $paypalOrderID);
+
+        // Retrieve Paypal order details
+        $details = $this->orderDetailsApi->get($token, $paypalOrderID);
+        $orderDetailstatus = $this->propertyAccessor->getValue($details, '[status]');
+
+        if ($orderDetailstatus === StatusAction::STATUS_COMPLETED
+            || $orderDetailstatus === StatusAction::STATUS_PROCESSING) {
+            $this->_markOrderStatus($details, $payment,$orderDetailstatus);
+        } else {
+            if (isset($detailsComplete['debug_id'])) {
+                $this->_processError($detailsComplete, $payment);
+            }
+        }
+    }
+
+    /**
+     * @param array $orderDetails
+     * @param PaymentInterface $payment
+     * @param string $status
+     * @return void
+     * @throws \SM\SMException
+     */
+    private function _markOrderStatus(array $orderDetails, PaymentInterface $payment, string $status): void
+    {
+        $detailsPayment = [
+            'status' => $status,
+            'paypal_order_id' => $this->propertyAccessor->getValue($orderDetails, '[id]'),
+            'reference_id' => $this->propertyAccessor->getValue(
+                $orderDetails, '[purchase_units][0][reference_id]'
+            )
+        ];
+
+        if ($status === StatusAction::STATUS_COMPLETED) {
+            $detailsPayment = array_merge([
+                'transaction_id' => $this->propertyAccessor->getValue(
+                    $orderDetails, '[purchase_units][0][payments][captures][0][id]'
+                )
+            ], $detailsPayment);
+        }
+        $payment->setDetails($detailsPayment);
+
+        // Update state machine
+        $stateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
+        if ($stateMachine->can(PaymentTransitions::TRANSITION_PROCESS)) {
+            $stateMachine->apply(PaymentTransitions::TRANSITION_PROCESS);
+        }
+
+        if ($stateMachine->can(PaymentTransitions::TRANSITION_COMPLETE) && $status == StatusAction::STATUS_COMPLETED) {
+            $stateMachine->apply(PaymentTransitions::TRANSITION_COMPLETE);
+        }
+
+        $this->paymentManager->flush();
+    }
+
+    /**
+     * @param array $err
+     * @param PaymentInterface $payment
+     * @return void
+     * @throws \SM\SMException
+     */
+    private function _processError(array $err, PaymentInterface $payment): void
+    {
+        if ($this->_isProcessorDeclineError($err) || $this->_isUnprocessableEntityError($err)) {
+
+            // Log error in payment details
+            $payment->setDetails(array_merge([
+                'status' => StatusAction::STATE_FAILED,
+                'error' => $err
+            ], $payment->getDetails()));
+
+            $stateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
+            if ($stateMachine->can(PaymentTransitions::TRANSITION_PROCESS)) {
+                $stateMachine->apply(PaymentTransitions::TRANSITION_PROCESS);
+            }
+
+            $stateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
+            if ($stateMachine->can(PaymentTransitions::TRANSITION_FAIL)) {
+                $stateMachine->apply(PaymentTransitions::TRANSITION_FAIL);
+            }
+
+            $this->paymentManager->flush();
+        }
+    }
+
+    /**
+     * @param array $err
+     * @return bool
+     */
+    private function _isProcessorDeclineError(array $err): bool
+    {
+        $issue = null;
+        if (isset($err['details']) && is_array($err['details']) && isset($err['details'][0]))
+            $issue = (string)$this->propertyAccessor->getValue($err, '[details][0][issue]');
+        return $issue === self::INSTRUMENT_DECLINED || $issue === self::PAYER_ACTION_REQUIRED;
+    }
+
+    /**
+     * @param array $err
+     * @return bool
+     */
+    private function _isUnprocessableEntityError(array $err): bool
+    {
+        $issue = null;
+        if (isset($err['details']) && is_array($err['details']) && isset($err['details'][0]))
+            $issue = (string)$this->propertyAccessor->getValue($err, '[details][0][issue]');
+        return $issue === self::DUPLICATE_INVOICE_ID;
+    }
+}


### PR DESCRIPTION
* Envoie du Order->number et du Order->id à la création de la commande côté Paypal afin d'éviter les doubles paiements
* Amélioration du process des webhookAction avec une mutualisation du code et la prise en compte des paiements en erreur au niveau de la capture de l'order