### PR TITLE
fix: [NEXT-679] Front - Paiement Paypal non disponible à cause d'arrondis non cohérents

### DIFF
--- a/src/Api/CreateOrderApi.php
+++ b/src/Api/CreateOrderApi.php
@@ -81,7 +81,7 @@ final class CreateOrderApi implements CreateOrderApiInterface
             $order->getShippingTotal(),
             (float)$payPalItemData['total_item_value'],
             (float)$payPalItemData['total_tax'],
-            abs((int)$payment->getAmount() - (int)(($payPalItemData['total_item_value'] * 100 + $payPalItemData['total_tax']*100 + $order->getShippingTotal()))), //$order->getOrderPromotionTotal(),
+            $this->getOrderPromotionTotal($payment, $order, $payPalItemData),
             (string)$config['merchant_id'],
             (array)$payPalItemData['items'],
             $order->isShippingRequired(),
@@ -114,5 +114,12 @@ final class CreateOrderApi implements CreateOrderApiInterface
             [$baseUrl, $order->getTokenValue()],
             ['return_url' => $config['return_url'], 'cancel_url' => $config['cancel_url']]
         );
+    }
+
+    private function getOrderPromotionTotal(PaymentInterface $payment, OrderInterface $order, array $payPalItemData): int
+    {
+        $totalItemValue = (int)$payPalItemData['total_item_value_int'];
+        $totalTax = (int)$payPalItemData['total_tax_int'];
+        return (int)($payment->getAmount() - ($totalItemValue + $totalTax + $order->getShippingTotal()));
     }
 }

--- a/src/Provider/PayPalItemDataProvider.php
+++ b/src/Provider/PayPalItemDataProvider.php
@@ -22,7 +22,9 @@ final class PayPalItemDataProvider implements PayPalItemDataProviderInterface
         $itemData = [
             'items' => [],
             'total_item_value' => 0,
+            'total_item_value_int' => 0,
             'total_tax' => 0,
+            'total_tax_int' => 0,
         ];
 
         /** @var Collection<int, OrderItemInterface> $orderItems */
@@ -36,7 +38,9 @@ final class PayPalItemDataProvider implements PayPalItemDataProviderInterface
                 $displayQuantity = $nonNeutralTaxes === [0] ? $orderItem->getQuantity() : 1;
                 $itemValue = $orderItem->getUnitPrice();
                 $itemData['total_item_value'] += ($itemValue * $displayQuantity) / 100;
+                $itemData['total_item_value_int'] += $itemValue * $displayQuantity;
                 $itemData['total_tax'] += ($nonNeutralTax * $displayQuantity) / 100;
+                $itemData['total_tax_int'] += $nonNeutralTax * $displayQuantity;
 
                 $itemData['items'][] = [
                     'name' => $orderItem->getProductName(),


### PR DESCRIPTION
Corrections du calcul du total des promotions, passage du calcul en full integer pour éviter le problème de la virgule floatante lors du cast d'un float -> int

(exemple: `(int) (290.15 * 100);` => 29014)